### PR TITLE
Add condition for root section translation slug.

### DIFF
--- a/Lib/SectionTranslationSluggableListener.php
+++ b/Lib/SectionTranslationSluggableListener.php
@@ -48,6 +48,8 @@ class SectionTranslationSluggableListener extends SluggableListener
         if ($translatable->getParent()) {
             $queryBuilder->andWhere('t.parent = :parent')
                 ->setParameter('parent', $translatable->getParent());
+        } else {
+            $queryBuilder->andWhere('t.parent IS NULL');
         }
 
         return $queryBuilder;


### PR DESCRIPTION
Query should return only entities on the same level, wasn't the case for root section.